### PR TITLE
🐛 Update Sonar organisation and project keys.

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=jaskfla_typefaceoff
-sonar.organization=jaskfla
+sonar.projectKey=typefaceoff_typefaceoff
+sonar.organization=typefaceoff
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=typefaceoff


### PR DESCRIPTION
Transferring ownership of the repo from @jaskfla to @typefaceoff broke the SonarCloude integration.

I’ve updated the GitHub Secret `SONAR_TOKEN` value already, and this fix should restore the SonarCloud GitHub Action.