### PR TITLE
Establish `ROADMAP.md` and remove `ARCHITECTURE.md` references.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,34 +20,34 @@ Welcome to the **Typefaceoff** open-source community! We greatly appreciate your
 If you encounter a bug or issue while using **Typefaceoff**, we encourage you to report it to us. Please follow these steps when filing a bug report:
 
 1. Go to the project’s [issue tracker](https://github.com/jaskfla/typefaceoff/issues).
-2. Click on “New Issue” and select the “Bug Report” template.
-3. Provide a clear and concise title for the issue.
-4. Describe the problem you encountered and the steps to reproduce it.
-5. Include relevant information like your operating system, browser version, and any error messages received.
-6. To provide this detail, stack traces, test cases, screenshots, code examples, and/or error reports may be added.
-7. Tag the issue appropriately for better tracking.
+1. Click on “New Issue” and select the “Bug Report” template.
+1. Provide a clear and concise title for the issue.
+1. Describe the problem you encountered and the steps to reproduce it.
+1. Include relevant information like your operating system, browser version, and any error messages received.
+1. To provide this detail, stack traces, test cases, screenshots, code examples, and/or error reports may be added.
+1. Tag the issue appropriately for better tracking.
 
 ## How to Suggest a New Feature
 
 We value your ideas and suggestions for improving **Typefaceoff**. To suggest a new feature, follow these steps:
 
 1. Go to the project’s [issue tracker](https://github.com/jaskfla/typefaceoff/issues).
-2. Click on “New Issue” and select the “Feature Request” template.
-3. Give your feature request a descriptive title.
-4. Clearly explain the feature’s purpose and how it would benefit the project.
-5. Consider including any relevant use cases or examples to support your request.
+1. Click on “New Issue” and select the “Feature Request” template.
+1. Give your feature request a descriptive title.
+1. Clearly explain the feature’s purpose and how it would benefit the project.
+1. Consider including any relevant use cases or examples to support your request.
 
 ## How to Submit a Pull Request
 
 Contributions through pull requests are crucial to the success of **Typefaceoff**. To submit a pull request, follow these guidelines:
 
 1. Fork the repository on GitHub.
-2. Create a new branch for your changes.
-3. Make your changes and commit them with descriptive messages.
-4. Ensure your code adheres to our coding standards and style guidelines.
-5. Write tests to cover your changes whenever applicable.
-6. Open a pull request and provide a detailed description of your changes.
-7. Be prepared for constructive feedback during the code review process.
+1. Create a new branch for your changes.
+1. Make your changes and commit them with descriptive messages.
+1. Ensure your code adheres to our coding standards and style guidelines.
+1. Write tests to cover your changes whenever applicable.
+1. Open a pull request and provide a detailed description of your changes.
+1. Be prepared for constructive feedback during the code review process.
 
 ## Setting Up Your Environment and Running Tests
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,6 +90,6 @@ We expect all contributors to follow our project's code of conduct. You can find
 If you have any questions, suggestions, or need further assistance, you can get in touch with us through the following channels:
 
 - Opening an issue in the [issue tracker](https://github.com/your-organization/project-name/issues).
-- Sending an email to typefaceoff@gmail.com.
+- Sending an email to [typefaceoff@gmail.com](mailto:typefaceoff@gmail.com).
 
 Remember to keep communication respectful and constructive. We are excited to collaborate with you!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,8 +19,8 @@ Welcome to the **Typefaceoff** open-source community! We greatly appreciate your
 
 If you encounter a bug or issue while using **Typefaceoff**, we encourage you to report it to us. Please follow these steps when filing a bug report:
 
-1. Go to the project's [issue tracker](https://github.com/jaskfla/typefaceoff/issues).
-2. Click on "New Issue" and select the "Bug Report" template.
+1. Go to the project’s [issue tracker](https://github.com/jaskfla/typefaceoff/issues).
+2. Click on “New Issue” and select the “Bug Report” template.
 3. Provide a clear and concise title for the issue.
 4. Describe the problem you encountered and the steps to reproduce it.
 5. Include relevant information like your operating system, browser version, and any error messages received.
@@ -31,10 +31,10 @@ If you encounter a bug or issue while using **Typefaceoff**, we encourage you to
 
 We value your ideas and suggestions for improving **Typefaceoff**. To suggest a new feature, follow these steps:
 
-1. Go to the project's [issue tracker](https://github.com/jaskfla/typefaceoff/issues).
-2. Click on "New Issue" and select the "Feature Request" template.
+1. Go to the project’s [issue tracker](https://github.com/jaskfla/typefaceoff/issues).
+2. Click on “New Issue” and select the “Feature Request” template.
 3. Give your feature request a descriptive title.
-4. Clearly explain the feature's purpose and how it would benefit the project.
+4. Clearly explain the feature’s purpose and how it would benefit the project.
 5. Consider including any relevant use cases or examples to support your request.
 
 ## How to Submit a Pull Request
@@ -63,27 +63,27 @@ To set up your development environment and run tests for **Typefaceoff**, refer 
 - Performance optimizations
 - Translation improvements
 
-We appreciate and value all contributions that align with the project's goals.
+We appreciate and value all contributions that align with the project’s goals.
 
 ## Getting Started for Newcomers
 
-We encourage newcomers to start their journey by contributing to beginner-friendly issues. Look for issues labeled "Good First Issue" in the [issue tracker](https://github.com/your-organization/project-name/issues) to get started easily.
+We encourage newcomers to start their journey by contributing to beginner-friendly issues. Look for issues labeled “Good First Issue” in the [issue tracker](https://github.com/your-organization/project-name/issues) to get started easily.
 
 ## Technical Requirements for Contributions
 
 When making contributions, please adhere to the following technical requirements:
 
 - Include relevant tests with each code change.
-- Follow the project's coding conventions and style guidelines.
+- Follow the project’s coding conventions and style guidelines.
 - Ensure your code is compatible with the supported environments and dependencies.
 
 ## Project Roadmap and Vision
 
-For an overview of our project's roadmap and vision, refer to [ROADMAP.md](ROADMAP.md) in the repository.
+For an overview of our project’s roadmap and vision, refer to [ROADMAP.md](ROADMAP.md) in the repository.
 
 ## Project Ground Rules and Expected Behavior
 
-We expect all contributors to follow our project's code of conduct. You can find the code of conduct in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+We expect all contributors to follow our project’s code of conduct. You can find the code of conduct in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## How to Get in Touch
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,16 +5,15 @@ Welcome to the **Typefaceoff** open-source community! We greatly appreciate your
 ## Table of Contents
 
 1. [How to File a Bug Report](#how-to-file-a-bug-report)
-2. [How to Suggest a New Feature](#how-to-suggest-a-new-feature)
-3. [How to Submit a Pull Request](#how-to-submit-a-pull-request)
-4. [Setting Up Your Environment and Running Tests](#setting-up-your-environment-and-running-tests)
-5. [Types of Contributions](#types-of-contributions)
-6. [Getting Started for Newcomers](#getting-started-for-newcomers)
-7. [Technical Requirements for Contributions](#technical-requirements-for-contributions)
-8. [Project Roadmap and Vision](#project-roadmap-and-vision)
-9. [High-Level Design / Architecture Information](#high-level-design-architecture-information)
-10. [Project Ground Rules and Expected Behavior](#project-ground-rules-and-expected-behavior)
-11. [How to Get in Touch](#how-to-get-in-touch)
+1. [How to Suggest a New Feature](#how-to-suggest-a-new-feature)
+1. [How to Submit a Pull Request](#how-to-submit-a-pull-request)
+1. [Setting Up Your Environment and Running Tests](#setting-up-your-environment-and-running-tests)
+1. [Types of Contributions](#types-of-contributions)
+1. [Getting Started for Newcomers](#getting-started-for-newcomers)
+1. [Technical Requirements for Contributions](#technical-requirements-for-contributions)
+1. [Project Roadmap and Vision](#project-roadmap-and-vision)
+1. [Project Ground Rules and Expected Behavior](#project-ground-rules-and-expected-behavior)
+1. [How to Get in Touch](#how-to-get-in-touch)
 
 ## How to File a Bug Report
 
@@ -81,10 +80,6 @@ When making contributions, please adhere to the following technical requirements
 ## Project Roadmap and Vision
 
 For an overview of our project's roadmap and vision, refer to [ROADMAP.md](ROADMAP.md) in the repository.
-
-## High-Level Design / Architecture Information
-
-Detailed high-level design and architecture information can be found in [ARCHITECTURE.md](ARCHITECTURE.md) in the repository.
 
 ## Project Ground Rules and Expected Behavior
 

--- a/.github/ROADMAP.md
+++ b/.github/ROADMAP.md
@@ -4,8 +4,30 @@
 
 This living document serves to plainly lay out features that are actively being worked on, planned, or under review.
 
-Everyone is welcome to peruse and contribute to our [issues](https://github.com/typefaceoff/typefaceoff/issues). If there’s something you think would be a good addition to Typefaceoff, but it isn’t mentioned here, we encourage you to open a new issue. (If you aren’t sure how to go about that, no worries—check out our [contributing guidelines](https://github.com/typefaceoff/typefaceoff/blob/main/.github/CONTRIBUTING.md).)
+Everyone is welcome to peruse and contribute to our [issues](https://github.com/typefaceoff/typefaceoff/issues). If there’s something you think would be a good addition to Typefaceoff, but it isn’t mentioned here, we encourage you to open a new issue. (If you aren’t sure how to go about that, no worries—check out our [contributing guidelines](CONTRIBUTING.md).)
 
 ## 🧹 Housekeeping
 
 Minor bug fixes and enhancements to existing features don’t need to be mentioned here! This roadmap is about the big picture.
+
+## 🗺️ Feature roadmap
+
+*Last updated August 14, 2023.*
+
+### Planned for v0.1 (August 23, 2023)
+
+#### Side-by-side comparison of two fonts
+
+The core-most feature of this tool. A user should be able to drag and drop two fonts into Typefaceoff in the browser, and see two side-by-side “pages”—each effectively a type specimen—one typeset in each of the imported fonts.
+
+- At this stage, text in the proofing template will be fixed and uneditable by the user—unless they’re savvy enough to edit the page source. (If that’s you, you might make a good [contributor](CONTRIBUTING.md) around these parts!)
+- To ensure the user is never at risk of violating any of their font licences, the fonts should be accessed using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) or [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).
+
+#### Configurable leading
+
+Simply changing the typeface used to typeset a document does not lend itself to fair comparison between two choices. This is, in part, because the *point size* of a font is [surprisingly non-standard](https://tonsky.me/blog/font-size). Different typefaces need to be set at different point sizes, with different line spacing, to optically *appear* as though they’re otherwise typeset similarly.
+
+The user should be able to adjust the line spacing (within a small but reasonable range) separately for each font being compared. This lets them see the text typeset closer to how they would use it in production, rather than having to optimise for one font at the detriment of the other.
+
+> [!NOTE]
+> **Leading** (pronounced *ledding*) is the traditional term for **line spacing**, because printers used to put strips of lead between lines to adjust line spacing.

--- a/.github/ROADMAP.md
+++ b/.github/ROADMAP.md
@@ -31,3 +31,39 @@ The user should be able to adjust the line spacing (within a small but reasonabl
 
 > [!NOTE]
 > **Leading** (pronounced *ledding*) is the traditional term for **line spacing**, because printers used to put strips of lead between lines to adjust line spacing.
+
+#### Comparison of OpenType feature support
+
+For typesetting in English, OpenType features are used to access alternate glyphs in a font, enabling features such as ligatures, proportional/tabular figures, lining/old-style figures, ordinals, true superscript & subscript figures, among others. OpenType features are a domain in which typeface designers can flex their muscles, and support for and execution of OpenType features can be a major deciding factor for some typesetters.
+
+> [!NOTE]
+> OpenType was primarily developed for improved support for various international writing systems. OpenType features are somewhat of a luxury when typesetting in Latin script, but are table-stakes for some languages such as Arabic or Urdu.
+
+Typefaceoff should reveal what OpenType features a font supports, let the user enable/disable individual features used in the proofing template, and/or select the stylistic set(s) used.
+
+### Planned for v0.2 (September 29, 2023)
+
+- Allow the user to customise the text used in the proofing template(s).
+- Configurable colours.
+- Export type specimen to PDF.
+
+### Planned for v0.3 (October 20, 2023)
+
+- Support testing of Google Fonts.
+- Multiple proofing templates, to compare fonts in different contexts.
+	- e.g., Article, web page, research paper.
+
+### Under review
+
+#### Comparison of more than two fonts at a time
+
+#### Configurable tracking
+
+At small point sizes, fonts need more generous letterspacing to maintain legibility. This is especially the case if a particular font does not support [optical sizing](https://justanotherfoundry.com/size-specific-adjustments-to-type-designs).
+
+Given that we cannot know what point sizes at which the user would like to use the fonts they’re testing, we may want to consider letting the user configure the letterspacing used in the proofing template. This lets them optimise for the particular point sizes they are most interested in.
+
+It may also be pertinent to testing all caps or small caps fonts, where increased letterspacing often improves legibility.
+
+> [!NOTE]
+> **Tracking**, **letterspacing**, and **character spacing** are interchangeable times

--- a/.github/ROADMAP.md
+++ b/.github/ROADMAP.md
@@ -1,0 +1,11 @@
+# Typefaceoff Development Roadmap
+
+## 👋 Context
+
+This living document serves to plainly lay out features that are actively being worked on, planned, or under review.
+
+Everyone is welcome to peruse and contribute to our [issues](https://github.com/typefaceoff/typefaceoff/issues). If there’s something you think would be a good addition to Typefaceoff, but it isn’t mentioned here, we encourage you to open a new issue. (If you aren’t sure how to go about that, no worries—check out our [contributing guidelines](https://github.com/typefaceoff/typefaceoff/blob/main/.github/CONTRIBUTING.md).)
+
+## 🧹 Housekeeping
+
+Minor bug fixes and enhancements to existing features don’t need to be mentioned here! This roadmap is about the big picture.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=typefaceoff_typefaceoff
-sonar.organization=typefaceoff
+sonar.projectKey=jaskfla_typefaceoff
+sonar.organization=jaskfla
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=typefaceoff

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=jaskfla_typefaceoff
-sonar.organization=jaskfla
+sonar.projectKey=typefaceoff_typefaceoff
+sonar.organization=typefaceoff
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=typefaceoff


### PR DESCRIPTION
## Changes to `CONTRIBUTING.md`

- Removed references to a non-existent (and irrelevant) architecture document in the contributing guidelines.
- Educated the quotes in the contributing guidelines (i.e., replaced straight quotes with curly quotes).
- Removed table of contents section, because GitHub automatically generates an interactive table of contents based on headings in the Markdown file anyway.
- Replaced sequential numbering of ordered lists in `CONTRIBUDING.md` with simply `1. `. This makes future diffs much cleaner if the lists ever change.

## `ROADMAP.md`

Wrote out v0.1 (Assignment 1) roadmap in detail, and less detail for subsequent releases (for now).