### PR TITLE
Improved Drop Areas

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "fontkit": "^2.0.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-dropzone": "^14.2.3"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-dropzone:
+    specifier: ^14.2.3
+    version: 14.2.3(react@18.2.0)
 
 devDependencies:
   '@types/react':
@@ -767,6 +770,11 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /attr-accept@2.2.2:
+    resolution: {integrity: sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==}
+    engines: {node: '>=4'}
+    dev: false
+
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
@@ -1308,6 +1316,13 @@ packages:
     dependencies:
       flat-cache: 3.0.4
     dev: true
+
+  /file-selector@0.6.0:
+    resolution: {integrity: sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==}
+    engines: {node: '>= 12'}
+    dependencies:
+      tslib: 2.6.1
+    dev: false
 
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -1903,7 +1918,6 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -2096,7 +2110,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -2117,9 +2130,20 @@ packages:
       scheduler: 0.23.0
     dev: false
 
+  /react-dropzone@14.2.3(react@18.2.0):
+    resolution: {integrity: sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
+    dependencies:
+      attr-accept: 2.2.2
+      file-selector: 0.6.0
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: false
+
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}

--- a/src/components/FontUploader.tsx
+++ b/src/components/FontUploader.tsx
@@ -7,7 +7,7 @@ const FontUploader: React.FC<{ onFontSelected: (selectedFont: File | null) => vo
 }) => {
   const [, setSelectedFont] = useState<File | null>(null);
   const [, setFontPreview] = useState<string | null>(null);
-  
+
   const onDrop = useCallback((acceptedFiles: Array<File>) => {
     const allowedExtensions = ['.otf', '.ttf', '.woff', '.woff2'];
     const fontFiles = acceptedFiles.filter((file) => {
@@ -20,29 +20,29 @@ const FontUploader: React.FC<{ onFontSelected: (selectedFont: File | null) => vo
       onFontSelected(selectedFile);
       setFontPreview(URL.createObjectURL(selectedFile));
     }
-  }, [])
+  }, []);
 
-  const { getRootProps, getInputProps, isDragActive, isFocused } = useDropzone({ onDrop, maxFiles: 1});
+  const { getRootProps, getInputProps, isDragActive, isFocused } = useDropzone({
+    onDrop,
+    maxFiles: 1,
+  });
 
   const focusedStyle = {
-    borderColor: '#2196f3'
+    borderColor: '#2196f3',
   };
 
-  const style = useMemo(() => ({
-    ...(isFocused ? focusedStyle : {}),
-  }), [
-    isFocused,
-  ]);
+  const style = useMemo(
+    () => ({
+      ...(isFocused ? focusedStyle : {}),
+    }),
+    [isFocused]
+  );
 
   return (
     <form>
-      <div {...getRootProps({ className: 'drop-area', style})}>
+      <div {...getRootProps({ className: 'drop-area', style })}>
         <input {...getInputProps()} />
-        {
-          isDragActive ?
-            <p>Drop here...</p> :
-            <p>Drag and drop a font file here</p>
-        }
+        {isDragActive ? <p>Drop here...</p> : <p>Drag and drop a font file here</p>}
       </div>
     </form>
   );

--- a/src/components/FontUploader.tsx
+++ b/src/components/FontUploader.tsx
@@ -10,29 +10,32 @@ const FontUploader: React.FC<{ onFontSelected: (selectedFont: File | null) => vo
   const initialTxt = 'Drag and drop font files here';
   const [text, setText] = React.useState(initialTxt);
 
-  const onDrop = useCallback((acceptedFiles: Array<File>) => {
-    const allowedExtensions = ['.otf', '.ttf', '.woff', '.woff2'];
-    const fontFiles = acceptedFiles.filter((file) => {
-      const extension = file.name.split('.').pop()?.toLowerCase();
-      return allowedExtensions.includes(`.${extension}`);
-    });
-    if (fontFiles.length > 0) {
-      const selectedFile = fontFiles[0];
-      setSelectedFont(selectedFile);
-      onFontSelected(selectedFile);
-      setFontPreview(URL.createObjectURL(selectedFile));
+  const onDrop = useCallback(
+    (acceptedFiles: Array<File>) => {
+      const allowedExtensions = ['.otf', '.ttf', '.woff', '.woff2'];
+      const fontFiles = acceptedFiles.filter((file) => {
+        const extension = file.name.split('.').pop()?.toLowerCase();
+        return allowedExtensions.includes(`.${extension}`);
+      });
+      if (fontFiles.length > 0) {
+        const selectedFile = fontFiles[0];
+        setSelectedFont(selectedFile);
+        onFontSelected(selectedFile);
+        setFontPreview(URL.createObjectURL(selectedFile));
 
-      // Set text as font name uploaded
-      const fileName = selectedFile.name;
-      const name = fileName.split('.').slice(0, -1).join('.');
-      setText(name);
-    }
-  }, [onFontSelected]);
+        // Set text as font name uploaded
+        const fileName = selectedFile.name;
+        const name = fileName.split('.').slice(0, -1).join('.');
+        setText(name);
+      }
+    },
+    [onFontSelected]
+  );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     maxFiles: 1,
-    multiple: false
+    multiple: false,
   });
 
   return (

--- a/src/components/FontUploader.tsx
+++ b/src/components/FontUploader.tsx
@@ -39,15 +39,17 @@ const FontUploader: React.FC<{ onFontSelected: (selectedFont: File | null) => vo
   };
 
   return (
-    <div className="drop-area" onDrop={handleDrop} onDragOver={handleDragOver}>
-      <p>Drag and drop a font file here</p>
-      <input
-        className="input-button"
-        type="file"
-        accept=".otf, .ttf, .woff, .woff2"
-        onChange={handleFileChange}
-      />
-    </div>
+    <form>
+      <div className="drop-area" onDrop={handleDrop} onDragOver={handleDragOver}>
+        <p>Drag and drop a font file here</p>
+        <input
+          className="input-button"
+          type="file"
+          accept=".otf, .ttf, .woff, .woff2"
+          onChange={handleFileChange}
+        />
+      </div>
+    </form>
   );
 };
 

--- a/src/components/FontUploader.tsx
+++ b/src/components/FontUploader.tsx
@@ -1,53 +1,48 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState, useMemo } from 'react';
 import '../styles/FontUploader.css';
+import { useDropzone } from 'react-dropzone';
 
 const FontUploader: React.FC<{ onFontSelected: (selectedFont: File | null) => void }> = ({
   onFontSelected,
 }) => {
   const [, setSelectedFont] = useState<File | null>(null);
   const [, setFontPreview] = useState<string | null>(null);
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
-      const file = e.target.files[0];
-      setSelectedFont(file);
-      onFontSelected(file);
-      setFontPreview(URL.createObjectURL(file));
-    }
-  };
-
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const files = Array.from(e.dataTransfer.files);
-
+  
+  const onDrop = useCallback((acceptedFiles: Array<File>) => {
     const allowedExtensions = ['.otf', '.ttf', '.woff', '.woff2'];
-    const fontFiles = files.filter((file) => {
+    const fontFiles = acceptedFiles.filter((file) => {
       const extension = file.name.split('.').pop()?.toLowerCase();
       return allowedExtensions.includes(`.${extension}`);
     });
-
     if (fontFiles.length > 0) {
       const selectedFile = fontFiles[0];
       setSelectedFont(selectedFile);
       onFontSelected(selectedFile);
       setFontPreview(URL.createObjectURL(selectedFile));
     }
+  }, [])
+
+  const { getRootProps, getInputProps, isDragActive, isFocused } = useDropzone({ onDrop, maxFiles: 1});
+
+  const focusedStyle = {
+    borderColor: '#2196f3'
   };
 
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-  };
+  const style = useMemo(() => ({
+    ...(isFocused ? focusedStyle : {}),
+  }), [
+    isFocused,
+  ]);
 
   return (
     <form>
-      <div className="drop-area" onDrop={handleDrop} onDragOver={handleDragOver}>
-        <p>Drag and drop a font file here</p>
-        <input
-          className="input-button"
-          type="file"
-          accept=".otf, .ttf, .woff, .woff2"
-          onChange={handleFileChange}
-        />
+      <div {...getRootProps({ className: 'drop-area', style})}>
+        <input {...getInputProps()} />
+        {
+          isDragActive ?
+            <p>Drop here...</p> :
+            <p>Drag and drop a font file here</p>
+        }
       </div>
     </form>
   );

--- a/src/components/FontUploader.tsx
+++ b/src/components/FontUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useMemo } from 'react';
+import React, { useCallback, useState} from 'react';
 import '../styles/FontUploader.css';
 import { useDropzone } from 'react-dropzone';
 
@@ -20,27 +20,17 @@ const FontUploader: React.FC<{ onFontSelected: (selectedFont: File | null) => vo
       onFontSelected(selectedFile);
       setFontPreview(URL.createObjectURL(selectedFile));
     }
-  }, []);
+  }, [onFontSelected]);
 
-  const { getRootProps, getInputProps, isDragActive, isFocused } = useDropzone({
+  const { getRootProps, getInputProps, isDragActive} = useDropzone({
     onDrop,
-    maxFiles: 1,
+    maxFiles: 1, 
+    multiple: false
   });
-
-  const focusedStyle = {
-    borderColor: '#2196f3',
-  };
-
-  const style = useMemo(
-    () => ({
-      ...(isFocused ? focusedStyle : {}),
-    }),
-    [isFocused]
-  );
 
   return (
     <form>
-      <div {...getRootProps({ className: 'drop-area', style })}>
+      <div {...getRootProps({ className: 'drop-area'})}>
         <input {...getInputProps()} />
         {isDragActive ? <p>Drop here...</p> : <p>Drag and drop a font file here</p>}
       </div>

--- a/src/components/FontUploader.tsx
+++ b/src/components/FontUploader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState} from 'react';
+import React, { useCallback, useState } from 'react';
 import '../styles/FontUploader.css';
 import { useDropzone } from 'react-dropzone';
 
@@ -7,6 +7,8 @@ const FontUploader: React.FC<{ onFontSelected: (selectedFont: File | null) => vo
 }) => {
   const [, setSelectedFont] = useState<File | null>(null);
   const [, setFontPreview] = useState<string | null>(null);
+  const initialTxt = 'Drag and drop font files here';
+  const [text, setText] = React.useState(initialTxt);
 
   const onDrop = useCallback((acceptedFiles: Array<File>) => {
     const allowedExtensions = ['.otf', '.ttf', '.woff', '.woff2'];
@@ -19,20 +21,25 @@ const FontUploader: React.FC<{ onFontSelected: (selectedFont: File | null) => vo
       setSelectedFont(selectedFile);
       onFontSelected(selectedFile);
       setFontPreview(URL.createObjectURL(selectedFile));
+
+      // Set text as font name uploaded
+      const fileName = selectedFile.name;
+      const name = fileName.split('.').slice(0, -1).join('.');
+      setText(name);
     }
   }, [onFontSelected]);
 
-  const { getRootProps, getInputProps, isDragActive} = useDropzone({
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
-    maxFiles: 1, 
+    maxFiles: 1,
     multiple: false
   });
 
   return (
     <form>
-      <div {...getRootProps({ className: 'drop-area'})}>
+      <div {...getRootProps({ className: 'drop-area' })}>
         <input {...getInputProps()} />
-        {isDragActive ? <p>Drop here...</p> : <p>Drag and drop a font file here</p>}
+        {isDragActive ? <p>Drop here...</p> : <p>{text}</p>}
       </div>
     </form>
   );

--- a/src/styles/FontUploader.css
+++ b/src/styles/FontUploader.css
@@ -1,5 +1,4 @@
 .drop-area {
-    position: relative;
     align-items: center;
     border-radius: 24px;
     border: 2px dashed var(--color-border);

--- a/src/styles/FontUploader.css
+++ b/src/styles/FontUploader.css
@@ -14,4 +14,3 @@
 .selected-fonts {
     margin-top: 10px;
 }
-

--- a/src/styles/FontUploader.css
+++ b/src/styles/FontUploader.css
@@ -8,26 +8,10 @@
     padding: 2rem 2.5rem;
     text-align: center;
     width: 100%;
+    cursor: pointer;
 }
 
 .selected-fonts {
     margin-top: 10px;
 }
 
-.input-button {
-    /* Cross-browser opacity lines*/
-    opacity: 0.0;
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
-    filter: alpha(opacity=0);
-    -moz-opacity: 0.0;
-    -khtml-opacity: 0.0;
- 
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    width: 100%;
-    height:100%;
-    cursor: pointer;
- }

--- a/src/styles/FontUploader.css
+++ b/src/styles/FontUploader.css
@@ -1,4 +1,5 @@
 .drop-area {
+    position: relative;
     align-items: center;
     border-radius: 24px;
     border: 2px dashed var(--color-border);
@@ -14,6 +15,19 @@
 }
 
 .input-button {
-    margin-block-start: 10px;
-    padding-inline-start: 40px;
-}
+    /* Cross-browser opacity lines*/
+    opacity: 0.0;
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+    filter: alpha(opacity=0);
+    -moz-opacity: 0.0;
+    -khtml-opacity: 0.0;
+ 
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height:100%;
+    cursor: pointer;
+ }


### PR DESCRIPTION
### Changes

Describe the Pull Request here. Add any references and info to help reviewers understand your changes.

- Implemented react-dropzone which streamlines the functionality between dragging and clicking to choose a font file, additionally removes the `input` boxes, leaving only drop areas
- Removed unnecessary functions such as `handleFileChange`, `handleDrop` and `handleDragOver` in `FontUploader.tsx`

### Tests applied

What testing has been applied to validate changes are accurate and correct

- Personal testing

### Issue ticket number(s)

Enter the issue numbers resolved by this pull request

- Partly addresses #46 , still needs to display font names

### Checklist

- [ ] Documented
- [ ] Linting tests successful
- [ ] merge updated prod branch into development branch
