### PR TITLE
Added otf feature detection and display

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,5 +14,6 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
+    "@typescript-eslint/no-explicit-any": ["off"]
   },
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "husky": "husky install"
   },
   "dependencies": {
+    "@types/opentype.js": "^1.3.6",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",
+    "opentype.js": "^1.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,18 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@types/opentype.js':
+    specifier: ^1.3.6
+    version: 1.3.6
   html2canvas:
     specifier: ^1.4.1
     version: 1.4.1
   jspdf:
     specifier: ^2.5.1
     version: 2.5.1
+  opentype.js:
+    specifier: ^1.3.4
+    version: 1.3.4
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -491,6 +497,10 @@ packages:
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
     dev: true
+
+  /@types/opentype.js@1.3.6:
+    resolution: {integrity: sha512-dUWq16/odeIvR/HCNZT+6BQ1x/hQKxkmdkq992TNfpx1b1onwqJEeHlKW+TrJgYiPDNv9J5qHdYlfZPfcbaGsA==}
+    dev: false
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
@@ -2056,6 +2066,15 @@ packages:
       is-wsl: 2.2.0
     dev: true
 
+  /opentype.js@1.3.4:
+    resolution: {integrity: sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+    dependencies:
+      string.prototype.codepointat: 0.2.1
+      tiny-inflate: 1.0.3
+    dev: false
+
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -2387,6 +2406,10 @@ packages:
     dev: false
     optional: true
 
+  /string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+    dev: false
+
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
@@ -2488,6 +2511,10 @@ packages:
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
+
+  /tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+    dev: false
 
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
 import { proofingText } from './constants';
+import opentype from 'opentype.js';
 
 function App() {
   // State for the selected font on the left
@@ -20,14 +21,40 @@ function App() {
   // State for the line height on the left
   const [lineHeightLeft, setLineHeightLeft] = useState<number>(1.5);
 
+  // Opentype feature option names from the gsub table of the font file on the left
+  const [fontFeatureOptionsLeft, setFontFeatureOptionsLeft] = useState<unknown[]>([]);
+
+  // Opentype feature option names from the gsub table of the font file on the right
+  const [fontFeatureOptionsRight, setFontFeatureOptionsRight] = useState<unknown[]>([]);
+
   // Handler for when a font is selected on the left side
   const handleFontSelectedLeft = (selectedFont: File | null) => {
     setSelectedFontLeft(selectedFont);
+    if (selectedFont != null) {
+      const buffer = selectedFont.arrayBuffer();
+      buffer.then((data) => {
+        const otfFont = opentype.parse(data);
+        const featureNames = [
+          ...Array.from(new Set(otfFont.tables.gsub.features.map((f: any) => f.tag))),
+        ];
+        setFontFeatureOptionsLeft(featureNames);
+      });
+    }
   };
 
   // Handler for when a font is selected on the right side
   const handleFontSelectedRight = (selectedFont: File | null) => {
     setSelectedFontRight(selectedFont);
+    if (selectedFont != null) {
+      const buffer = selectedFont.arrayBuffer();
+      buffer.then((data) => {
+        const otfFont = opentype.parse(data);
+        const featureNames = [
+          ...Array.from(new Set(otfFont.tables.gsub.features.map((f: any) => f.tag))),
+        ];
+        setFontFeatureOptionsRight(featureNames);
+      });
+    }
   };
 
   // Event handler to set a common text for all proof elements
@@ -86,7 +113,7 @@ function App() {
               onChange={(e) => setLineHeightLeft(parseFloat(e.target.value))}
             />
           </div>
-
+          <p>Font features detected: {fontFeatureOptionsLeft.toString()}</p>
           {<FontPreview fontFile={selectedFontLeft} side="left" lineHeight={lineHeightLeft} />}
         </section>
 
@@ -105,6 +132,7 @@ function App() {
               onChange={(e) => setLineHeightRight(parseFloat(e.target.value))}
             />
           </div>
+          <p>Font features detected: {fontFeatureOptionsRight.toString()}</p>
           {<FontPreview fontFile={selectedFontRight} side="right" lineHeight={lineHeightRight} />}
         </section>
       </main>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -119,7 +119,9 @@ function App() {
               onChange={(e) => setLineHeightLeft(parseFloat(e.target.value))}
             />
           </div>
-          <div><p>Font features detected: {fontFeatureOptionsLeft.toString()}</p></div>
+          <div>
+            <p>Font features detected: {fontFeatureOptionsLeft.toString()}</p>
+          </div>
           {<FontPreview fontFile={selectedFontLeft} side="left" lineHeight={lineHeightLeft} />}
           <div className="font-preview">
             {<FontPreview fontFile={selectedFontLeft} side="left" lineHeight={lineHeightLeft} />}
@@ -143,7 +145,9 @@ function App() {
               onChange={(e) => setLineHeightRight(parseFloat(e.target.value))}
             />
           </div>
-          <div><p>Font features detected: {fontFeatureOptionsRight.toString()}</p></div>
+          <div>
+            <p>Font features detected: {fontFeatureOptionsRight.toString()}</p>
+          </div>
           <div className="font-preview">
             {<FontPreview fontFile={selectedFontRight} side="right" lineHeight={lineHeightRight} />}
           </div>


### PR DESCRIPTION
### Changes

- opentype.js library added to dependencies
- Added detection of opentype features from gsub table of font file to App.tsx.
- When a font is dropped, opentype features are displayed as text underneath the line height div.

### Tests applied

Tested with otf fonts with known features. Features were recorded correctly. Fonts with no features return an empty list.

### Issue ticket number(s)

- [#73 ](https://github.com/typefaceoff/typefaceoff/issues/73)

### Checklist

- [ ] Documented
- [ ] Linting tests successful
- [ ] merge updated prod branch into development branch
