### PR TITLE
Feat/alternate proofing templates

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -158,12 +158,13 @@ function App() {
           <div className="font-uploader">
             <FontUploader onFontSelected={handleFontSelectedLeft} />
           </div>
-          <div>
+          <div className="font-uploader">
             <GoogleFontLoader onFontLoaded={handleGoogleFontLeft} />
           </div>
           <div className="line-height-adjustment">
             <label htmlFor="lineHeightInputLeft">Line spacing: </label>
             <input
+              className="lineHeightInput"
               type="number"
               id="lineHeightInputLeft"
               value={lineHeightLeft}
@@ -204,12 +205,13 @@ function App() {
           <div className="font-uploader">
             <FontUploader onFontSelected={handleFontSelectedRight} />
           </div>
-          <div>
+          <div className="font-uploader">
             <GoogleFontLoader onFontLoaded={handleGoogleFontRight} />
           </div>
           <div className="line-height-adjustment">
             <label htmlFor="lineHeightInputRight">Line spacing: </label>
             <input
+              className="lineHeightInput"
               type="number"
               id="lineHeightInputRight"
               value={lineHeightRight}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -146,6 +146,11 @@ function App() {
         >
           Save previews as PDF
         </button>
+        <select className="dropdown">
+          <option value="Paragraph">Paragraph</option>
+          <option value="Article">Article</option>
+          <option value="Research Paper">Research Paper</option>
+        </select>
       </header>
       <main>
         {/* Left side */}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 import '../styles/App.css';
 import FontUploader from './FontUploader';
 import FontPreview from './FontPreview';
+import Article from './Article';
 import { BsGithub } from 'react-icons/bs';
 import { useState } from 'react';
 import { proofingText, opentypeText } from './constants';
@@ -9,6 +10,9 @@ import FontFeaturesSetting from './FontFeaturesSetting';
 import GoogleFontLoader from './GoogleFontLoader';
 
 function App() {
+  // Current proof template
+  const [selectedTemplate, setSelectedTemplate] = useState('Font Preview');
+
   // State for the selected font on the left
   const [selectedFontLeft, setSelectedFontLeft] = useState<File | null>(null);
 
@@ -146,8 +150,12 @@ function App() {
         >
           Save previews as PDF
         </button>
-        <select className="dropdown">
-          <option value="Paragraph">Paragraph</option>
+        <select
+          className="dropdown"
+          value={selectedTemplate}
+          onChange={(e) => setSelectedTemplate(e.target.value)}
+        >
+          <option value="Font Preview">Font Preview</option>
           <option value="Article">Article</option>
           <option value="Research Paper">Research Paper</option>
         </select>
@@ -187,7 +195,7 @@ function App() {
             }
           </div>
           <div className="font-preview">
-            {
+            {selectedTemplate === 'Font Preview' && (
               <FontPreview
                 fontFile={selectedFontLeft}
                 googleFontData={googleFontLeft}
@@ -196,7 +204,27 @@ function App() {
                 fontFeatureOptions={fontFeatureOptionsLeft}
                 fontSettings={fontSettingsLeft}
               />
-            }
+            )}
+            {selectedTemplate === 'Article' && (
+              <Article
+                fontFile={selectedFontLeft}
+                googleFontData={googleFontLeft}
+                side="left"
+                lineHeight={lineHeightLeft}
+                fontFeatureOptions={fontFeatureOptionsLeft}
+                fontSettings={fontSettingsLeft}
+              />
+            )}
+            {selectedTemplate === 'Research Paper' && (
+              <FontPreview
+                fontFile={selectedFontLeft}
+                googleFontData={googleFontLeft}
+                side="left"
+                lineHeight={lineHeightLeft}
+                fontFeatureOptions={fontFeatureOptionsLeft}
+                fontSettings={fontSettingsLeft}
+              />
+            )}
           </div>
         </section>
 
@@ -234,7 +262,7 @@ function App() {
             }
           </div>
           <div className="font-preview">
-            {
+            {selectedTemplate === 'Font Preview' && (
               <FontPreview
                 fontFile={selectedFontRight}
                 googleFontData={googleFontRight}
@@ -243,7 +271,27 @@ function App() {
                 fontFeatureOptions={fontFeatureOptionsRight}
                 fontSettings={fontSettingsRight}
               />
-            }
+            )}
+            {selectedTemplate === 'Article' && (
+              <Article
+                fontFile={selectedFontRight}
+                googleFontData={googleFontRight}
+                side="right"
+                lineHeight={lineHeightRight}
+                fontFeatureOptions={fontFeatureOptionsRight}
+                fontSettings={fontSettingsRight}
+              />
+            )}
+            {selectedTemplate === 'Research Paper' && (
+              <FontPreview
+                fontFile={selectedFontRight}
+                googleFontData={googleFontRight}
+                side="right"
+                lineHeight={lineHeightRight}
+                fontFeatureOptions={fontFeatureOptionsRight}
+                fontSettings={fontSettingsRight}
+              />
+            )}
           </div>
         </section>
       </main>

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable react-refresh/only-export-components */
+import React from 'react';
+import FontTextPlaceholders from './FontTextPlaceholders';
+import postcss from 'postcss';
+
+interface FontPreviewProps {
+  fontFile: File | null;
+  googleFontData: string | null;
+  side: 'left' | 'right';
+  lineHeight: number;
+  fontFeatureOptions: string[];
+  fontSettings: boolean[];
+}
+
+function getFontFamily(fontFile: File | string | null, side: string) {
+  if (fontFile) {
+    return side === 'left' ? 'CustomFontLeft' : 'CustomFontRight';
+  }
+  return 'var(--font-stack-default)';
+}
+
+function getFontSettings(featureOptions: string[], featureSettings: boolean[]) {
+  let setting = ``;
+  for (let i = 0; i < featureOptions.length; i++) {
+    if (featureSettings[i]) {
+      setting += "'" + featureOptions[i] + "'" + ' on,';
+    } else {
+      setting += "'" + featureOptions[i] + "'" + ' off,';
+    }
+  }
+  setting = setting.slice(0, -1);
+  return setting;
+}
+
+const FontPreview: React.FC<FontPreviewProps> = ({
+  fontFile,
+  googleFontData,
+  side,
+  lineHeight,
+  fontFeatureOptions,
+  fontSettings,
+}) => {
+  let fontUrl = '';
+  let fontFamily = '';
+  let fontFace = '';
+
+  if (googleFontData && !fontFile) {
+    fontFamily = getFontFamily(googleFontData, side);
+    const parsedCss = postcss.parse(googleFontData);
+    parsedCss.walkAtRules('font-face', (rule) => {
+      rule.walkDecls('font-family', (decl) => {
+        decl.value = `${fontFamily}`;
+      });
+    });
+    fontFace = parsedCss.toString();
+  }
+
+  if (fontFile && !googleFontData) {
+    fontUrl = fontFile ? URL.createObjectURL(fontFile) : '';
+    fontFamily = getFontFamily(fontFile, side);
+
+    fontFace = `
+      @font-face {
+        font-family: '${fontFamily}';
+        src: url(${fontUrl}) format('opentype');
+        font-display: swap;
+      }
+    `;
+  }
+
+  const featureSettings = getFontSettings(fontFeatureOptions, fontSettings);
+
+  const fontStyles: React.CSSProperties = {
+    fontFamily: fontFamily,
+    fontFeatureSettings: featureSettings,
+  };
+
+  return (
+    <section>
+      <style>{fontFace}</style>
+      <div style={fontStyles}>
+        <FontTextPlaceholders lineHeight={lineHeight} />
+        <FontTextPlaceholders lineHeight={lineHeight} />
+      </div>
+    </section>
+  );
+};
+
+// Only re-render if fontFile, lineHeight, or side props change
+export default React.memo(FontPreview, (prevProps, nextProps) => {
+  return (
+    prevProps.fontFile === nextProps.fontFile &&
+    prevProps.googleFontData === nextProps.googleFontData &&
+    prevProps.lineHeight === nextProps.lineHeight &&
+    prevProps.side === nextProps.side &&
+    prevProps.fontFeatureOptions === nextProps.fontFeatureOptions &&
+    prevProps.fontSettings === nextProps.fontSettings
+  );
+});

--- a/src/components/ProofFullWidthLine.tsx
+++ b/src/components/ProofFullWidthLine.tsx
@@ -21,6 +21,7 @@ export default function FullWidthLine(proofingText: string, pointSize: number, l
       <p
         className="full-width-line proof"
         contentEditable
+        spellCheck="false"
         onInput={updateProofingText}
         style={paragraphStyle}
       >

--- a/src/components/ProofHalfWidthLine.tsx
+++ b/src/components/ProofHalfWidthLine.tsx
@@ -22,6 +22,7 @@ export default function HalfWidthLine(proofingText: string, pointSize: number, l
       <p
         className="half-width-line proof"
         contentEditable
+        spellCheck="false"
         onInput={updateProofingText}
         style={paragraphStyle}
       >

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -42,6 +42,40 @@ main {
     margin-bottom: 15px;
     margin-left: 10px;
     margin-right: 10px;
+    transition: background-color 0.4s;
+}
+
+.button:hover {
+    background-color: #404040;
+}
+
+.dropdown {
+    margin-bottom: 15px;
+    margin-left: 10px;
+    margin-right: 10px;
+    color: aliceblue;
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    text-align: center;
+    border: 1px solid transparent;
+    padding: 0.6em 1.2em;
+    font-size: 1rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background-color 0.4s;
+}
+
+.dropdown:hover {
+    background-color: #404040;
+}
+
+.dropdown option {
+    background-color: #1a1a1a; /* Or any color you want */
+    color: aliceblue; /* Or any color you want */
+}
+
+.dropdown:hover option {
+    background-color: #1a1a1a; /* Or any color you want */
 }
 
 footer {

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -78,27 +78,6 @@ main {
     background-color: #1a1a1a; /* Or any color you want */
 }
 
-#lineHeightInputLeft {
-    border: 2px solid #ccc; /* Light dashed border */
-    border-radius: 8px; /* Rounded corners */
-    background-color: white; /* Optional: Make the background transparent */
-    padding: 8px; /* Adjust padding according to your preference */
-    font-size: 16px; /* Adjust font size according to your preference */
-    text-align: center;
-    color: #333; /* Text color */
-    transition: background-color 0.4s;
-    width: fit-content;
-}
-
-#lineHeightInputLeft:hover {
-    background-color: #f0f0f0;
-}
-
-#lineHeightInputLeft:focus {
-    outline: none; /* Removes the default outline */
-    border: 2px solid rgb(182, 173, 173);
-}
-
 .lineHeightInput {
     border: 2px solid #ccc; /* Light dashed border */
     border-radius: 8px; /* Rounded corners */
@@ -108,7 +87,7 @@ main {
     text-align: center;
     color: #333; /* Text color */
     transition: background-color 0.4s;
-    width: fit-content;
+    width: 5rem;
 }
 
 .lineHeightInput:hover {

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -58,11 +58,12 @@ main {
     border-radius: 8px;
     text-align: center;
     border: 1px solid transparent;
-    padding: 0.6em 1.2em;
     font-size: 1rem;
     font-family: inherit;
     cursor: pointer;
     transition: background-color 0.4s;
+    font-weight: 500;
+    padding: 0.6em 1.2em;
 }
 
 .dropdown:hover {
@@ -70,6 +71,9 @@ main {
 }
 
 .dropdown option {
+    border-radius: 8px;
+    text-align: center;
+    width: 100%;
     background-color: #1a1a1a; /* Or any color you want */
     color: aliceblue; /* Or any color you want */
 }

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -78,6 +78,48 @@ main {
     background-color: #1a1a1a; /* Or any color you want */
 }
 
+#lineHeightInputLeft {
+    border: 2px solid #ccc; /* Light dashed border */
+    border-radius: 8px; /* Rounded corners */
+    background-color: white; /* Optional: Make the background transparent */
+    padding: 8px; /* Adjust padding according to your preference */
+    font-size: 16px; /* Adjust font size according to your preference */
+    text-align: center;
+    color: #333; /* Text color */
+    transition: background-color 0.4s;
+    width: fit-content;
+}
+
+#lineHeightInputLeft:hover {
+    background-color: #f0f0f0;
+}
+
+#lineHeightInputLeft:focus {
+    outline: none; /* Removes the default outline */
+    border: 2px solid rgb(182, 173, 173);
+}
+
+.lineHeightInput {
+    border: 2px solid #ccc; /* Light dashed border */
+    border-radius: 8px; /* Rounded corners */
+    background-color: white; /* Optional: Make the background transparent */
+    padding: 8px; /* Adjust padding according to your preference */
+    font-size: 16px; /* Adjust font size according to your preference */
+    text-align: center;
+    color: #333; /* Text color */
+    transition: background-color 0.4s;
+    width: fit-content;
+}
+
+.lineHeightInput:hover {
+    background-color: #f0f0f0;
+}
+
+.lineHeightInput:focus {
+    outline: none; /* Removes the default outline */
+    border: 2px solid rgb(182, 173, 173);
+}
+
 footer {
     display: flex;
     align-items: center;
@@ -91,6 +133,7 @@ footer {
     .title,
     .subtitle,
     .button,
+    .dropdown,
     .font-features,
     .font-uploader,
     .footer-text,

--- a/src/styles/FontUploader.css
+++ b/src/styles/FontUploader.css
@@ -9,6 +9,11 @@
     width: 100%;
     height: 7.5rem;
     cursor: pointer;
+    transition: background-color 0.4s;
+}
+
+.drop-area:hover {
+    background-color: #f0f0f0;
 }
 
 .selected-fonts {

--- a/src/styles/FontUploader.css
+++ b/src/styles/FontUploader.css
@@ -6,6 +6,7 @@
     flex-direction: column;
     padding: 1.5rem 2rem;
     text-align: center;
+    color: #666666; /* Text color */
     width: 100%;
     height: 7.5rem;
     cursor: pointer;

--- a/src/styles/GoogleFontLoader.css
+++ b/src/styles/GoogleFontLoader.css
@@ -9,6 +9,11 @@
     font-size: 18px;
     display: flex;
     flex-direction: row;
+    transition: background-color 0.4s;
+}
+
+.submitButton:hover {
+    background-color: #404040;
 }
 
 .borderless-input {
@@ -21,6 +26,11 @@
     display: flex;
     flex-direction: row;
     width: 100%;
+    transition: background-color 0.4s;
+}
+
+.borderless-input:hover {
+    background-color: #f0f0f0;
 }
 
 .google-font-bar {

--- a/src/styles/GoogleFontLoader.css
+++ b/src/styles/GoogleFontLoader.css
@@ -1,5 +1,5 @@
 .submitButton {
-    background-color: black; /* Green */
+    background-color: #1a1a1a;
     color: aliceblue;
     border: none;
     border-radius: 0px 12px 12px 0px;
@@ -31,6 +31,11 @@
 
 .borderless-input:hover {
     background-color: #f0f0f0;
+}
+
+.borderless-input:focus {
+    outline: none; /* Removes the default outline */
+    border: 2px solid rgb(182, 173, 173);
 }
 
 .google-font-bar {

--- a/src/styles/ProofFullWidthLine.css
+++ b/src/styles/ProofFullWidthLine.css
@@ -3,6 +3,7 @@
     flex-direction: row;
     align-items: stretch;
     gap: 0.5rem;
+    transition: background-color 0.4s;
 }
 
 .full-width-line {
@@ -13,4 +14,9 @@
     width: 100%;
     max-width: 100%;
     line-height: 1.15;
+    transition: background-color 0.4s;
+}
+
+.full-width-line:hover {
+    background-color: rgb(252, 228, 226);
 }

--- a/src/styles/ProofHalfWidthLine.css
+++ b/src/styles/ProofHalfWidthLine.css
@@ -1,3 +1,8 @@
 .half-width-line {
     margin-block-start: 0px;
+    transition: background-color 0.4s;
+}
+
+.half-width-line:hover {
+    background-color: rgb(252, 228, 226);
 }


### PR DESCRIPTION
### Changes

- Added simple transition highlights for components to improve user experience
- Implemented drop-down menu for transitioning between different proof templates
- Added Article template, although it is currently just two FontTextPlacerholders. Will implement the article structure in a future pull request.

### Tests applied

- Changes are working as intended on both Firefox and Chrome

### Issue ticket number(s)

Enter the issue numbers resolved by this pull request

- Closes #92 

### Checklist

- [ ] Documented
- [x] Linting tests successful
- [ ] merge updated prod branch into development branch
