### PR TITLE
fix: overflow issue with half-width-lines

### DIFF
--- a/src/components/ProofHalfWidthLine.tsx
+++ b/src/components/ProofHalfWidthLine.tsx
@@ -23,7 +23,7 @@ export default function HalfWidthLine(
 
   if (!sizingToken) {
     return (
-      <div>
+      <div className="half-width-line-container">
         <p
           className="half-width-line proof"
           contentEditable
@@ -38,7 +38,7 @@ export default function HalfWidthLine(
   }
 
   return (
-    <div>
+    <div className="half-width-line-container">
       {SizingToken(pointSize, pointSize * lineHeight)}
       <p
         className="half-width-line proof"

--- a/src/styles/ProofHalfWidthLine.css
+++ b/src/styles/ProofHalfWidthLine.css
@@ -3,8 +3,14 @@
     transition: background-color 0.4s;
     padding-top: 10px;
     padding-bottom: 10px;
+    text-overflow: clip;
+    overflow-y: clip;
 }
 
 .half-width-line:hover {
     background-color: rgb(252, 228, 226);
+}
+
+.half-width-line-container {
+    width: 48%;
 }


### PR DESCRIPTION
### Changes

Describe the Pull Request here. Add any references and info to help reviewers understand your changes.

- Half-Width-Line components no longer overflow. 

![overflow](https://github.com/typefaceoff/typefaceoff/assets/86962800/06223408-4eeb-4191-beee-1fad37cc3c57)

### Tests applied

What testing has been applied to validate changes are accurate and correct

- Checked all the proofing templates

### Issue ticket number(s)

Enter the issue numbers resolved by this pull request

Closes #109 

### Checklist

- [ ] Documented
- [ ] Linting tests successful
- [ ] merge updated prod branch into development branch
