### PR TITLE
fix article header text

### DIFF
--- a/src/components/TemplatePlaceHolders/ArticleTextPlaceHolders.tsx
+++ b/src/components/TemplatePlaceHolders/ArticleTextPlaceHolders.tsx
@@ -17,11 +17,8 @@ export default function ArticleTextPlaceholders({ lineHeight }: ArticleTextPlace
         {FullWidthLine(articleText, displayPointSizes[0], lineHeight, false)}
       </div>
       <div className="template-double-columns">
-        {/* {HalfWidthLine(articleTitle, displayPointSizes[1], lineHeight, false)}
-        {HalfWidthLine(articleSubTitle, displayPointSizes[2], lineHeight, false)} */}
         {TitleLine(articleTitle, displayPointSizes[1], lineHeight, false)}
       </div>
-
       <div className="template-single-column">
         {FullWidthLine(articleAuthorLine, displayPointSizes[3], 1.5, false)}
       </div>

--- a/src/components/TemplatePlaceHolders/ArticleTextPlaceHolders.tsx
+++ b/src/components/TemplatePlaceHolders/ArticleTextPlaceHolders.tsx
@@ -1,6 +1,7 @@
 import '../../styles/FontTextPlaceholders.css';
 import FullWidthLine from '../LineFormats/ProofFullWidthLine';
 import HalfWidthLine from '../LineFormats/ProofHalfWidthLine';
+import TitleLine from '../LineFormats/ProofTitleLine';
 import { articleText, articleTitle, articleSubTitle, articleAuthorLine } from '../constants';
 
 interface ArticleTextPlaceholdersProps {
@@ -16,9 +17,11 @@ export default function ArticleTextPlaceholders({ lineHeight }: ArticleTextPlace
         {FullWidthLine(articleText, displayPointSizes[0], lineHeight, false)}
       </div>
       <div className="template-double-columns">
-        {HalfWidthLine(articleTitle, displayPointSizes[1], lineHeight, false)}
-        {HalfWidthLine(articleSubTitle, displayPointSizes[2], lineHeight, false)}
+        {/* {HalfWidthLine(articleTitle, displayPointSizes[1], lineHeight, false)}
+        {HalfWidthLine(articleSubTitle, displayPointSizes[2], lineHeight, false)} */}
+        {TitleLine(articleTitle, displayPointSizes[1], lineHeight, false)}
       </div>
+
       <div className="template-single-column">
         {FullWidthLine(articleAuthorLine, displayPointSizes[3], 1.5, false)}
       </div>

--- a/src/components/TemplatePlaceHolders/ArticleTextPlaceHolders.tsx
+++ b/src/components/TemplatePlaceHolders/ArticleTextPlaceHolders.tsx
@@ -2,7 +2,7 @@ import '../../styles/FontTextPlaceholders.css';
 import FullWidthLine from '../LineFormats/ProofFullWidthLine';
 import HalfWidthLine from '../LineFormats/ProofHalfWidthLine';
 import TitleLine from '../LineFormats/ProofTitleLine';
-import { articleText, articleTitle, articleSubTitle, articleAuthorLine } from '../constants';
+import { articleText, articleTitle, articleAuthorLine } from '../constants';
 
 interface ArticleTextPlaceholdersProps {
   readonly lineHeight: number;

--- a/src/components/constants/index.tsx
+++ b/src/components/constants/index.tsx
@@ -3,7 +3,7 @@ export const opentypeText = `The quick brown fox jumps over the lazy dog. 123456
 
 /** Article Proofing Text */
 export const articleText = `A bizarre series of natural disasters has struck this once golden city. Earthquakes, tsunamis, volcanic eruptions, massive landslides, and sinkholes have caused Atlantis to sink over 10 kilometers into the Atlantic Ocean. Miraculously all individuals were able to be evacuated from the city a week prior, when authorities became deeply concerned over the rising sea levels in the city due to the volcanic disaster in March this year.`;
-export const articleTitle = `BREAKING NEWS:`;
+export const articleTitle = `BREAKING NEWS`;
 export const articleSubTitle = `City of Atlantis deep in the Atlantic due to biggest natural disaster in history!`;
 export const articleAuthorLine = `Primary Reporter: Plato, Primary Journalist: Timaeus Critias, 360 BC`;
 


### PR DESCRIPTION
### Changes

- Fix width of article template, breaking news default text is being cut off. 
- Width is changed

### Tests applied

Manual testing - Article template fixed

### Issue ticket number(s)

Closes #133 

### Checklist

- [ ] Documented
- [ ] Linting tests successful
- [ ] merge updated prod branch into development branch
